### PR TITLE
✨ Add multi pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ if (typeof input === 'string') {
 
 </details>
 
+### Is this library code compatible with IE11?
+
+No, the library depends on [rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Rest_parameters), [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), object [shorthand method definitions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions), and other features (but polyfill-able) from modern JS. If you need to support older browsers, include `lil-match` from `node_modules` to your compiler white-list.
+
 ## 🙏 Acknowledgments
 
 - The library was heavily inspired by amazing [`ts-pattern`](https://github.com/gvergnaud/ts-pattern) and [`ts-pattern-matching`](https://github.com/WimJongeneel/ts-pattern-matching) libraries

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ let output = match(input)
   .exhaustive('Unhandled input')
 ```
 
-### `.with(pattern, callback(match))`
+### `.with(...patterns, callback(match))`
 
 Create a match pattern based on `input`. The pattern can be an object, primitive value, or `Number`, `String`, `Boolean`, `Symbol`, `BigInt` constructors for creating wildcard patterns. Use `callback` to access matched value. Returns an object with all [match](#matchinput) methods for chaining.
 
 #### Params
 
-- `pattern`
+- `...patterns`
   - can be an object, literal value, primitive, or `Number`, `String`, `Boolean`, `Symbol`, `BigInt` constructors
 - `callback(match)`
   - access matched value
@@ -138,6 +138,19 @@ let output = match(input)
   .with({ type: 'ready', data: { type: 'text' } }, (res) => res)
   .with({ type: 'pending' }, (res) => res)
   .with({ type: 'failed' }, (res) => res)
+  .exhaustive('Unhandled input')
+```
+
+##### Multiple patterns
+
+Specify multiple patterns as arguments. The last parameter should be a callback.
+
+```ts
+let input: string | number | bigint
+
+let output = match(input)
+  .with(Number, BigInt, (res) => console.log('Number-like'))
+  .with(String, (res) => console.log('String'))
   .exhaustive('Unhandled input')
 ```
 
@@ -377,7 +390,7 @@ No, the library depends on [rest parameters](https://developer.mozilla.org/en-US
 ## 🙏 Acknowledgments
 
 - The library was heavily inspired by amazing [`ts-pattern`](https://github.com/gvergnaud/ts-pattern) and [`ts-pattern-matching`](https://github.com/WimJongeneel/ts-pattern-matching) libraries
-- The icon in the title designed by [@keytofreedom](https://www.instagram.com/keytofreedom)
+- The icon designed by [@keytofreedom](https://www.instagram.com/keytofreedom)
 
 ---
 

--- a/mod.d.ts
+++ b/mod.d.ts
@@ -24,16 +24,16 @@ declare type OmitToken<T> = Pick<
 declare type NonEmpty<T> = {} extends T ? never : T
 declare type OmitValue<T> = Exclude<T, NonEmpty<OmitToken<T>>>
 
-declare type DeepExtract<A, B, N = never> = A extends object
-  ? B extends object
+declare type DeepExtract<T, U, N = never> = T extends object
+  ? U extends object
     ? OmitValue<{
-        [K in keyof A]: K extends keyof B
-          ? DeepExtract<A[K], B[K], TOKEN>
-          : A[K]
+        [K in keyof T]: K extends keyof U
+          ? DeepExtract<T[K], U[K], TOKEN>
+          : T[K]
       }>
     : N
-  : A extends B
-  ? A
+  : T extends U
+  ? T
   : N
 
 declare type Pattern<Input> = Input extends number
@@ -68,17 +68,17 @@ declare type Invert<Pattern> = Pattern extends NumberConstructor
   ? { [K in keyof Pattern]: Invert<Pattern[K]> }
   : never
 
-declare type DeepExclude<A, B, N = never> = A extends object
-  ? B extends object
+declare type DeepExclude<T, U, N = never> = T extends object
+  ? U extends object
     ? OmitValue<{
-        [K in keyof A]: K extends keyof B
-          ? DeepExclude<A[K], B[K], TOKEN>
-          : A[K]
+        [K in keyof T]: K extends keyof U
+          ? DeepExclude<T[K], U[K], TOKEN>
+          : T[K]
       }>
     : N
-  : A extends B
+  : T extends U
   ? N
-  : A
+  : T
 
 declare interface NonExhaustive<_> {}
 
@@ -87,8 +87,13 @@ declare interface Match<Input, Next = Input, Output = never> {
     pattern: P,
     callback: (result: R) => O,
   ): Match<Exclude<Input, I>, DeepExclude<Next, I>, O | Output>
-  with<P extends Pattern<Input>, O, I = Invert<P>, R = DeepExtract<Input, I>>(
-    ...args: [...patterns: P[], callback: (result: R) => O]
+  with<
+    P extends [Pattern<Input>, ...Pattern<Input>[]],
+    O,
+    I = Invert<P[number]>,
+    R = DeepExtract<Input, I>,
+  >(
+    ...args: [...patterns: P, callback: (result: R) => O]
   ): Match<Exclude<Input, I>, DeepExclude<Next, I>, O | Output>
   run(): [Next] extends [never] ? Output : Output | undefined
   otherwise: [Next] extends [never]

--- a/mod.d.ts
+++ b/mod.d.ts
@@ -87,6 +87,9 @@ declare interface Match<Input, Next = Input, Output = never> {
     pattern: P,
     callback: (result: R) => O,
   ): Match<Exclude<Input, I>, DeepExclude<Next, I>, O | Output>
+  with<P extends Pattern<Input>, O, I = Invert<P>, R = DeepExtract<Input, I>>(
+    ...args: [...patterns: P[], callback: (result: R) => O]
+  ): Match<Exclude<Input, I>, DeepExclude<Next, I>, O | Output>
   run(): [Next] extends [never] ? Output : Output | undefined
   otherwise: [Next] extends [never]
     ? never

--- a/mod.js
+++ b/mod.js
@@ -1,7 +1,6 @@
-let UNKNOWN = []
+const UNKNOWN = []
 
 const isObject = (input) => input != null && typeof input === 'object'
-
 const compare = (input) => (pattern) => {
   if (pattern === Boolean) return typeof input === 'boolean'
   if (pattern === String) return typeof input === 'string'
@@ -21,7 +20,7 @@ const compare = (input) => (pattern) => {
 
 export const match = (input, output = UNKNOWN) => ({
   with(...patterns) {
-    let callback = patterns.pop()
+    const callback = patterns.pop()
     if (patterns.some(compare(input))) output = callback(input)
     return this
   },

--- a/mod.js
+++ b/mod.js
@@ -13,11 +13,12 @@ function compare(input) {
     if (pattern === BigInt) return typeof input === 'bigint'
 
     if (isObject(pattern)) {
-      return isObject(input)
-        ? Object.keys(pattern).every(function (key) {
-            return compare(input[key])(pattern[key])
-          })
-        : false
+      return (
+        isObject(input) &&
+        Object.keys(pattern).every(function (key) {
+          return compare(input[key])(pattern[key])
+        })
+      )
     }
 
     return Object.is(input, pattern)

--- a/mod.js
+++ b/mod.js
@@ -1,31 +1,34 @@
-const UNKNOWN = []
+let UNKNOWN = Symbol()
 
 function isObject(input) {
   return input != null && typeof input === 'object'
 }
 
-function compare(input, pattern) {
-  if (pattern === Boolean) return typeof input === 'boolean'
-  if (pattern === String) return typeof input === 'string'
-  if (pattern === Number) return typeof input === 'number'
-  if (pattern === Symbol) return typeof input === 'symbol'
-  if (pattern === BigInt) return typeof input === 'bigint'
+function compare(input) {
+  return function (pattern) {
+    if (pattern === Boolean) return typeof input === 'boolean'
+    if (pattern === String) return typeof input === 'string'
+    if (pattern === Number) return typeof input === 'number'
+    if (pattern === Symbol) return typeof input === 'symbol'
+    if (pattern === BigInt) return typeof input === 'bigint'
 
-  if (isObject(pattern)) {
-    return isObject(input)
-      ? Object.keys(pattern).every(function (key) {
-          return compare(input[key], pattern[key])
-        })
-      : false
+    if (isObject(pattern)) {
+      return isObject(input)
+        ? Object.keys(pattern).every(function (key) {
+            return compare(input[key])(pattern[key])
+          })
+        : false
+    }
+
+    return Object.is(input, pattern)
   }
-
-  return Object.is(input, pattern)
 }
 
 export function match(input, output = UNKNOWN) {
   return {
-    with(pattern, callback) {
-      if (compare(input, pattern)) output = callback(input)
+    with(...patterns) {
+      let callback = patterns.pop()
+      if (patterns.some(compare(input))) output = callback(input)
       return this
     },
     exhaustive(message) {

--- a/mod.js
+++ b/mod.js
@@ -1,48 +1,40 @@
-let UNKNOWN = Symbol()
+let UNKNOWN = []
 
-function isObject(input) {
-  return input != null && typeof input === 'object'
-}
+const isObject = (input) => input != null && typeof input === 'object'
 
-function compare(input) {
-  return function (pattern) {
-    if (pattern === Boolean) return typeof input === 'boolean'
-    if (pattern === String) return typeof input === 'string'
-    if (pattern === Number) return typeof input === 'number'
-    if (pattern === Symbol) return typeof input === 'symbol'
-    if (pattern === BigInt) return typeof input === 'bigint'
+const compare = (input) => (pattern) => {
+  if (pattern === Boolean) return typeof input === 'boolean'
+  if (pattern === String) return typeof input === 'string'
+  if (pattern === Number) return typeof input === 'number'
+  if (pattern === Symbol) return typeof input === 'symbol'
+  if (pattern === BigInt) return typeof input === 'bigint'
 
-    if (isObject(pattern)) {
-      return (
-        isObject(input) &&
-        Object.keys(pattern).every(function (key) {
-          return compare(input[key])(pattern[key])
-        })
-      )
-    }
-
-    return Object.is(input, pattern)
+  if (isObject(pattern)) {
+    return (
+      isObject(input) &&
+      Object.keys(pattern).every((key) => compare(input[key])(pattern[key]))
+    )
   }
+
+  return Object.is(input, pattern)
 }
 
-export function match(input, output = UNKNOWN) {
-  return {
-    with(...patterns) {
-      let callback = patterns.pop()
-      if (patterns.some(compare(input))) output = callback(input)
-      return this
-    },
-    exhaustive(message) {
-      if (output === UNKNOWN) throw new Error(message)
-      return output
-    },
-    otherwise(cb) {
-      if (output === UNKNOWN) return cb(input)
-      return output
-    },
-    run() {
-      if (output === UNKNOWN) return
-      return output
-    },
-  }
-}
+export const match = (input, output = UNKNOWN) => ({
+  with(...patterns) {
+    let callback = patterns.pop()
+    if (patterns.some(compare(input))) output = callback(input)
+    return this
+  },
+  exhaustive(message) {
+    if (output === UNKNOWN) throw new Error(message)
+    return output
+  },
+  otherwise(cb) {
+    if (output === UNKNOWN) return cb(input)
+    return output
+  },
+  run() {
+    if (output === UNKNOWN) return
+    return output
+  },
+})

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -793,9 +793,42 @@ describe('match constructor', () => {
     expect(() => fn(pending)).toThrow(new Error(ERROR))
     expect(() => fn(failed)).toThrow(new Error(ERROR))
   })
+
+  test('multiple pattern of primitives', () => {
+    function fn(input: string | symbol | number | bigint | boolean) {
+      const result = match(input)
+        .with(Number, BigInt, (res) => {
+          expectType<number | bigint>(res)
+          return `number-like: ${res}` as const
+        })
+        .with(Boolean, (res) => {
+          expectType<boolean>(res)
+          return `boolean: ${res}` as const
+        })
+        .with(String, Symbol, (res) => {
+          expectType<string | symbol>(res)
+          return `string | symbol: ${res.toString()}` as const
+        })
+        .exhaustive('Unhandled input')
+
+      type Result =
+        | `number-like: ${number | bigint}`
+        | `boolean: ${boolean}`
+        | `string | symbol: ${string | boolean}`
+
+      expectType<Result>(result)
+      return result
+    }
+
+    expect(fn(100)).toBe(`number-like: 100`)
+    expect(fn(100n)).toBe(`number-like: 100`)
+    expect(fn('text')).toBe(`string | symbol: text`)
+    expect(fn(Symbol('unique'))).toBe(`string | symbol: Symbol(unique)`)
+    expect(fn(true)).toBe(`boolean: true`)
+  })
 })
 
-describe('multi pattern', () => {
+describe('multi pattern union', () => {
   test('run', () => {
     function fn(input: Type) {
       const result = match(input)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "repository": "exah/lil-match",
   "author": "John Grishin <r@exah.me>",
+  "sideEffects": false,
   "license": "MIT",
   "keywords": [
     "pattern",


### PR DESCRIPTION
~~After this PR we dropping support for IE11 will be necessary, because library will use rest paramters and arrow functions from ES6~~.

Actually the browser support will not change after merging of this PR.