### PR TITLE
🚧 Require `is` function [BREAKING]

### DIFF
--- a/mod.d.ts
+++ b/mod.d.ts
@@ -106,4 +106,10 @@ interface Match<Input, Next = Input, Output = never> {
     : NonExhaustive<Next>
 }
 
+export declare function is<
+  Input,
+  Type extends abstract new (...args: any) => any,
+>(
+  type: Type,
+): (input: Input) => input is Input extends InstanceType<Type> ? Input : never
 export declare function match<Input>(input: Input): Match<Input>

--- a/mod.js
+++ b/mod.js
@@ -1,17 +1,17 @@
-let UNKNOWN = []
+let PRIMITIVES = [Number, String, BigInt, Symbol, Boolean]
 
-let isObject = (input) => input && typeof input === 'object'
+export let is = (type) => (input) =>
+  input != null &&
+  (type === Object ? typeof input === 'object' : Object(input) instanceof type)
+
 let compare = (input) => (pattern) => {
-  if (pattern === Boolean) return typeof input === 'boolean'
-  if (pattern === String) return typeof input === 'string'
-  if (pattern === Number) return typeof input === 'number'
-  if (pattern === Symbol) return typeof input === 'symbol'
-  if (pattern === BigInt) return typeof input === 'bigint'
-  if (typeof pattern === 'function') return pattern(input)
+  if (typeof pattern === 'function') {
+    return PRIMITIVES.includes(pattern) ? is(pattern)(input) : pattern(input)
+  }
 
-  if (isObject(pattern)) {
+  if (is(Object)(pattern)) {
     return (
-      isObject(input) &&
+      is(Object)(input) &&
       Object.keys(pattern).every((key) => compare(input[key])(pattern[key]))
     )
   }
@@ -19,22 +19,22 @@ let compare = (input) => (pattern) => {
   return Object.is(input, pattern)
 }
 
-export let match = (input, output = UNKNOWN) => ({
+export let match = (input, output = PRIMITIVES) => ({
   with(...patterns) {
     let callback = patterns.pop()
     if (patterns.some(compare(input))) output = callback(input)
     return this
   },
   exhaustive(message) {
-    if (output === UNKNOWN) throw Error(message)
+    if (output === PRIMITIVES) throw Error(message)
     return output
   },
   otherwise(cb) {
-    if (output === UNKNOWN) return cb(input)
+    if (output === PRIMITIVES) return cb(input)
     return output
   },
   run() {
-    if (output === UNKNOWN) return
+    if (output === PRIMITIVES) return
     return output
   },
 })

--- a/mod.js
+++ b/mod.js
@@ -1,13 +1,11 @@
-let PRIMITIVES = [Number, String, BigInt, Symbol, Boolean]
+let UNKNOWN = []
 
 export let is = (type) => (input) =>
   input != null &&
   (type === Object ? typeof input === 'object' : Object(input) instanceof type)
 
 let compare = (input) => (pattern) => {
-  if (typeof pattern === 'function') {
-    return PRIMITIVES.includes(pattern) ? is(pattern)(input) : pattern(input)
-  }
+  if (typeof pattern === 'function') return pattern(input)
 
   if (is(Object)(pattern)) {
     return (
@@ -19,22 +17,22 @@ let compare = (input) => (pattern) => {
   return Object.is(input, pattern)
 }
 
-export let match = (input, output = PRIMITIVES) => ({
+export let match = (input, output = UNKNOWN) => ({
   with(...patterns) {
     let callback = patterns.pop()
     if (patterns.some(compare(input))) output = callback(input)
     return this
   },
   exhaustive(message) {
-    if (output === PRIMITIVES) throw Error(message)
+    if (output === UNKNOWN) throw Error(message)
     return output
   },
   otherwise(cb) {
-    if (output === PRIMITIVES) return cb(input)
+    if (output === UNKNOWN) return cb(input)
     return output
   },
   run() {
-    if (output === PRIMITIVES) return
+    if (output === UNKNOWN) return
     return output
   },
 })

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -572,7 +572,7 @@ describe('match constructor', () => {
   test('run', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Number } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -580,7 +580,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
+        .with({ type: Type.READY, data: { value: String } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -588,7 +588,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -629,7 +629,7 @@ describe('match constructor', () => {
   test('undefined on unhandled', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Number } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -637,7 +637,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
+        .with({ type: Type.READY, data: { value: String } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -664,7 +664,7 @@ describe('match constructor', () => {
   test('otherwise', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Number } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -672,7 +672,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
+        .with({ type: Type.READY, data: { value: String } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -680,7 +680,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -712,7 +712,7 @@ describe('match constructor', () => {
   test('exhaustive', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Number } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -720,7 +720,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
+        .with({ type: Type.READY, data: { value: String } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -728,7 +728,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -769,7 +769,7 @@ describe('match constructor', () => {
   test('not exhaustive', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
+        .with({ type: Type.READY, data: { value: Number } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -777,7 +777,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
+        .with({ type: Type.READY, data: { value: String } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import { Opaque } from 'type-fest'
-import { match } from '.'
+import { match, is } from '.'
 
 const ERROR = 'ERROR'
 const NOT_EXHAUSTIVE = 'NOT_EXHAUSTIVE'
@@ -572,7 +572,7 @@ describe('match constructor', () => {
   test('run', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -580,7 +580,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -588,7 +588,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -629,7 +629,7 @@ describe('match constructor', () => {
   test('undefined on unhandled', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -637,7 +637,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -664,7 +664,7 @@ describe('match constructor', () => {
   test('otherwise', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -672,7 +672,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -680,7 +680,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -712,7 +712,7 @@ describe('match constructor', () => {
   test('exhaustive', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -720,7 +720,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -728,7 +728,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -769,7 +769,7 @@ describe('match constructor', () => {
   test('not exhaustive', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -777,7 +777,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -958,9 +958,14 @@ describe('guards', () => {
     name: string
   }
 
-  interface Post {
+  class Post {
     id: UUID
     title: string
+
+    constructor(title: string) {
+      this.id = id
+      this.title = title
+    }
   }
 
   type Input = { data: Author } | { data: Post } | number[]
@@ -974,15 +979,6 @@ describe('guards', () => {
     )
   }
 
-  function isPost(input: unknown): input is Post {
-    return (
-      typeof input === 'object' &&
-      input != null &&
-      'id' in input &&
-      'title' in input
-    )
-  }
-
   test('run', () => {
     function fn(input: Input) {
       const result = match(input)
@@ -992,7 +988,7 @@ describe('guards', () => {
 
           return `Author: ${res.data.name}` as const
         })
-        .with({ data: isPost }, (res) => {
+        .with({ data: is(Post) }, (res) => {
           expectType<UUID>(res.data.id)
           expectType<string>(res.data.title)
 
@@ -1011,7 +1007,7 @@ describe('guards', () => {
     }
 
     expect(fn({ data: { id, name: 'John' } })).toBe('Author: John')
-    expect(fn({ data: { id, title: 'Bar' } })).toBe('Post: Bar')
+    expect(fn({ data: new Post('Bar') })).toBe('Post: Bar')
     expect(fn([1, 2, 3])).toBe('Array: 1, 2, 3')
     // @ts-expect-error
     expect(fn(NOT_EXHAUSTIVE)).toBe(undefined)

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -572,7 +572,7 @@ describe('match constructor', () => {
   test('run', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -580,7 +580,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -588,7 +588,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -629,7 +629,7 @@ describe('match constructor', () => {
   test('undefined on unhandled', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -637,7 +637,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -664,7 +664,7 @@ describe('match constructor', () => {
   test('otherwise', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -672,7 +672,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -680,7 +680,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -712,7 +712,7 @@ describe('match constructor', () => {
   test('exhaustive', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -720,7 +720,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -728,7 +728,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: Boolean } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Boolean) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'boolean'>(res.data.type)
           expectType<boolean>(res.data.value)
@@ -769,7 +769,7 @@ describe('match constructor', () => {
   test('not exhaustive', () => {
     function fn(input: Result) {
       const result = match(input)
-        .with({ type: Type.READY, data: { value: Number } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(Number) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'number'>(res.data.type)
           expectType<number>(res.data.value)
@@ -777,7 +777,7 @@ describe('match constructor', () => {
 
           return res.data.type
         })
-        .with({ type: Type.READY, data: { value: String } }, (res) => {
+        .with({ type: Type.READY, data: { value: is(String) } }, (res) => {
           expectType<Type.READY>(res.type)
           expectType<'string'>(res.data.type)
           expectType<string>(res.data.value)
@@ -802,15 +802,15 @@ describe('match constructor', () => {
   test('multiple pattern of primitives', () => {
     function fn(input: string | symbol | number | bigint | boolean) {
       const result = match(input)
-        .with(Number, BigInt, (res) => {
+        .with(is(Number), is(BigInt), (res) => {
           expectType<number | bigint>(res)
           return `number-like: ${res}` as const
         })
-        .with(Boolean, (res) => {
+        .with(is(Boolean), (res) => {
           expectType<boolean>(res)
           return `boolean: ${res}` as const
         })
-        .with(String, Symbol, (res) => {
+        .with(is(String), is(Symbol), (res) => {
           expectType<string | symbol>(res)
           return `string | symbol: ${res.toString()}` as const
         })


### PR DESCRIPTION
After this PR (if merged) it will be required to use `is` function to narrow type against constructor:

**Before**

```ts
import { match } from 'lil-match'

let input: string | number | bigint

let output = match(input)
  .with(Number, BigInt, (res) => console.log('Number-like'))
  .with(String, (res) => console.log('String'))
  .exhaustive('Unhandled input')
```

**After**

```ts
import { match, is } from 'lil-match'

let input: string | number | bigint

let output = match(input)
  .with(is(Number), is(BigInt), (res) => console.log('Number-like'))
  .with(is(String), (res) => console.log('String'))
  .exhaustive('Unhandled input')
```

However, bundled size of the lib is decreased by ~40 B

```sh
❯ npx size-limit
✔ Adding to empty esbuild project

  Package size is 48 B less than limit
  Size limit: 270 B
  Size:       222 B with all dependencies, minified and gzipped
```